### PR TITLE
chore: do not consider dokku as prod for mandatory variables

### DIFF
--- a/lib/env.ex
+++ b/lib/env.ex
@@ -11,7 +11,7 @@ defmodule Env do
 
   # will raise on prod start if env var is not defined
   def load_but_prod_mandatory(var_name, default \\ nil) do
-    if Application.get_env(:digiforma, :env) in [:dokku, :prod] do
+    if Application.get_env(:digiforma, :env) == :prod do
       load!(var_name)
     else
       load(var_name, default)
@@ -73,7 +73,8 @@ defmodule Env do
   end
 
   def load_into_boolean!(var_name) do
-    load!(var_name)
+    var_name
+    |> load!()
     |> load_boolean_from_string(var_name)
   end
 


### PR DESCRIPTION
Most env vars on dokku are set to "test", and dokku is a test platform

This way we can define default values for dokku env in `digiforma/config/runtime.exs`, and less vars are to be defined in GHA.